### PR TITLE
chore(e2e): update e2e text matching to be language agnostic

### DIFF
--- a/tests/e2e/audit-export.test.ts
+++ b/tests/e2e/audit-export.test.ts
@@ -1,6 +1,5 @@
 import type { ElectronApplication, Page } from "@playwright/test";
-import { expect, test } from "@playwright/test";
-import parseCsv from "csv-parse/lib/sync";
+import { test } from "@playwright/test";
 import fs from "fs";
 import path from "path";
 import { sync as rimrafSync } from "rimraf";
@@ -12,6 +11,7 @@ import {
   clickIcicleElement,
   makeExport,
 } from "./utils/app";
+import { getTextSelector } from "./utils/lang";
 import { closeApp, startApp } from "./utils/test";
 
 // eslint-disable-next-line @typescript-eslint/unbound-method
@@ -48,13 +48,13 @@ describe("Export audit report", () => {
   });
 
   afterEach(async () => {
-    rimrafSync(path.join(testFolderPath, "..","test-folder-audit_*.docx"));
+    rimrafSync(path.join(testFolderPath, "..", "test-folder-audit_*.docx"));
     await closeApp(app);
   });
 
   it("should generate an audit report", async () => {
     test.slow();
-    
+
     const tag0Name = "tag0";
     const tag1Name = "tag1";
     const description = "element description";
@@ -71,7 +71,7 @@ describe("Export audit report", () => {
     await makeExport(win, "AUDIT");
 
     // Waiting for the CSV file to be created
-    await win.waitForSelector(`text=/L'export du rapport d'audit est terminé/`);
+    await win.waitForSelector(getTextSelector("export.auditReportSuccess"));
 
     // Finding the CSV export file
     const exportFolderPath = path.join(__dirname, "..");

--- a/tests/e2e/deletion-script-export.test.ts
+++ b/tests/e2e/deletion-script-export.test.ts
@@ -1,6 +1,5 @@
 import type { ElectronApplication, Page } from "@playwright/test";
-import { expect, test } from "@playwright/test";
-import parseCsv from "csv-parse/lib/sync";
+import { test } from "@playwright/test";
 import fs from "fs";
 import path from "path";
 import { sync as rimrafSync } from "rimraf";
@@ -12,6 +11,7 @@ import {
   clickIcicleElement,
   makeExport,
 } from "./utils/app";
+import { getTextSelector } from "./utils/lang";
 import { closeApp, startApp } from "./utils/test";
 
 // eslint-disable-next-line @typescript-eslint/unbound-method
@@ -48,13 +48,13 @@ describe("Export deletion script", () => {
   });
 
   afterEach(async () => {
-    rimrafSync(path.join(testFolderPath, "..","test-folder-delete*.sh"));
+    rimrafSync(path.join(testFolderPath, "..", "test-folder-delete*.sh"));
     await closeApp(app);
   });
 
   it("should generate a deletion script", async () => {
     test.slow();
-    
+
     const tag0Name = "tag0";
     const tag1Name = "tag1";
     const description = "element description";
@@ -71,7 +71,9 @@ describe("Export deletion script", () => {
     await makeExport(win, "DELETION");
 
     // Waiting for the CSV file to be created
-    await win.waitForSelector(`text=/Le script de suppression a été généré/`);
+    await win.waitForSelector(
+      getTextSelector("export.deletionScriptSuccessMessage")
+    );
 
     // Finding the CSV export file
     const exportFolderPath = path.join(__dirname, "..");

--- a/tests/e2e/excel-export.test.ts
+++ b/tests/e2e/excel-export.test.ts
@@ -1,6 +1,5 @@
 import type { ElectronApplication, Page } from "@playwright/test";
-import { expect, test } from "@playwright/test";
-import parseCsv from "csv-parse/lib/sync";
+import { test } from "@playwright/test";
 import fs from "fs";
 import path from "path";
 import { sync as rimrafSync } from "rimraf";
@@ -12,6 +11,7 @@ import {
   clickIcicleElement,
   makeExport,
 } from "./utils/app";
+import { getTextSelector } from "./utils/lang";
 import { closeApp, startApp } from "./utils/test";
 
 // eslint-disable-next-line @typescript-eslint/unbound-method
@@ -48,13 +48,13 @@ describe("Export excel", () => {
   });
 
   afterEach(async () => {
-    rimrafSync(path.join(testFolderPath, "..","test-folder-excel_*.xlsx"));
+    rimrafSync(path.join(testFolderPath, "..", "test-folder-excel_*.xlsx"));
     await closeApp(app);
   });
 
   it("should generate an excel export", async () => {
     test.slow();
-    
+
     const tag0Name = "tag0";
     const tag1Name = "tag1";
     const description = "element description";
@@ -71,7 +71,9 @@ describe("Export excel", () => {
     await makeExport(win, "EXCEL");
 
     // Waiting for the CSV file to be created
-    await win.waitForSelector(`text=/L'export Excel est terminé/`);
+    await win.waitForSelector(
+      getTextSelector("export.excelExportSuccessMessage")
+    );
 
     // Finding the CSV export file
     const exportFolderPath = path.join(__dirname, "..");

--- a/tests/e2e/resip-export.test.ts
+++ b/tests/e2e/resip-export.test.ts
@@ -13,6 +13,7 @@ import {
   clickIcicleElement,
   makeExport,
 } from "./utils/app";
+import { getTextSelector } from "./utils/lang";
 import { closeApp, startApp } from "./utils/test";
 
 // eslint-disable-next-line @typescript-eslint/unbound-method
@@ -71,7 +72,9 @@ describe("Export to RESIP", () => {
     await makeExport(win, "RESIP");
 
     // Waiting for the RESIP file to be created
-    await win.waitForSelector(`text=/Fichier de métadonnées exporté dans le dossier racine du projet/`);
+    await win.waitForSelector(
+      getTextSelector("export.resipExportSuccessMessage")
+    );
 
     // Finding the RESIP export file
     const exportFolderPath = path.join(__dirname, "../test-folder");

--- a/tests/e2e/tree-csv-export.test.ts
+++ b/tests/e2e/tree-csv-export.test.ts
@@ -1,6 +1,5 @@
 import type { ElectronApplication, Page } from "@playwright/test";
-import { expect, test } from "@playwright/test";
-import parseCsv from "csv-parse/lib/sync";
+import { test } from "@playwright/test";
 import fs from "fs";
 import path from "path";
 import { sync as rimrafSync } from "rimraf";
@@ -12,6 +11,7 @@ import {
   clickIcicleElement,
   makeExport,
 } from "./utils/app";
+import { getTextSelector } from "./utils/lang";
 import { closeApp, startApp } from "./utils/test";
 
 // eslint-disable-next-line @typescript-eslint/unbound-method
@@ -48,13 +48,13 @@ describe("Export to tree CSV", () => {
   });
 
   afterEach(async () => {
-    rimrafSync(path.join(testFolderPath, "..","test-folder-treeCsv*.csv"));
+    rimrafSync(path.join(testFolderPath, "..", "test-folder-treeCsv*.csv"));
     await closeApp(app);
   });
 
   it("should generate a valid tree csv export", async () => {
     test.slow();
-    
+
     const tag0Name = "tag0";
     const tag1Name = "tag1";
     const description = "element description";
@@ -71,7 +71,7 @@ describe("Export to tree CSV", () => {
     await makeExport(win, "TREE_CSV");
 
     // Waiting for the CSV file to be created
-    await win.waitForSelector(`text=/L'export csv hiérarchisé est terminé/`);
+    await win.waitForSelector(getTextSelector("export.createdTreeCsvExport"));
 
     // Finding the CSV export file
     const exportFolderPath = path.join(__dirname, "..");

--- a/tests/e2e/utils/app.ts
+++ b/tests/e2e/utils/app.ts
@@ -90,20 +90,26 @@ export const addDescription = async (
   await win.mouse.click(10, 10);
 };
 
-type ExportType = "RESIP" | "CSV" | "CSV_WITH_HASHES" | "AUDIT" | "EXCEL" | "TREE_CSV" | "DELETION";
+type ExportType =
+  | "AUDIT"
+  | "CSV_WITH_HASHES"
+  | "CSV"
+  | "DELETION"
+  | "EXCEL"
+  | "RESIP"
+  | "TREE_CSV";
 
 /**
  * Triggers an export
  */
-export const makeExport = async (win: Page, type: ExportType): Promise<void> => {
+export const makeExport = async (
+  win: Page,
+  type: ExportType
+): Promise<void> => {
   await openExportMenu(win);
-  const exportTypeSelector = `export-type-container-${type}`
+  const exportTypeSelector = `export-type-container-${type}`;
   await win
-    .locator(
-      `${makeTestIdSelector(
-        exportTypeSelector
-      )} input[type="checkbox"]`
-    )
+    .locator(`${makeTestIdSelector(exportTypeSelector)} input[type="checkbox"]`)
     .click();
   await getLocatorByTestId(win, "export-submit").click();
 };

--- a/tests/e2e/utils/lang.ts
+++ b/tests/e2e/utils/lang.ts
@@ -1,0 +1,27 @@
+import { translations } from "@renderer/translations/translations";
+
+import { escapeRegexText } from "./regexp";
+
+const LANGUAGES = ["en", "fr", "de"];
+
+const getTextForAllLanguages = (translationSelector: string) =>
+  LANGUAGES.map((language) => getTextByLanguage(translationSelector, language));
+
+const getTextByLanguage = (translationSelector: string, language: string) =>
+  translations.t(translationSelector, { lng: language });
+
+export const getRegexSelector = (translationSelector: string): RegExp =>
+  new RegExp(
+    getTextForAllLanguages(translationSelector).map(escapeRegexText).join("|")
+  );
+
+export const getTextSelector = (translationSelector: string): string =>
+  `text=${getRegexSelector(translationSelector)}`;
+
+export const findTranslatedKey = <T extends Record<string, never>>(
+  object: T,
+  translationKey: string
+): string & (keyof T | "") =>
+  Object.keys(object).find((key) =>
+    getRegexSelector(translationKey).test(key)
+  ) ?? "";

--- a/tests/e2e/utils/regexp.ts
+++ b/tests/e2e/utils/regexp.ts
@@ -1,0 +1,6 @@
+/**
+ * Escape characters that would break a regex
+ * @param text
+ */
+export const escapeRegexText = (text: string) =>
+  text.replace(/[-/\\^$*+?.()|[\]{}]/g, "\\$&");


### PR DESCRIPTION
<!-- 🚨 Merci de respecter la convention semantic-pull-requests (https://github.com/zeke/semantic-pull-requests) principalement pour le titre de votre pull request. -->
<!-- Votre titre doit donc être de la forme : "feat:" ou "feat(xxx):", etc. -->

<!-- Lier le ticket associé (autocomplete à la place du "x" ou remplacer le "x" par l'id du ticket -->
Closes #1466

# Objectif(s)
<!-- Expliquer en quelques mots/phrases ce que cette PR permet d'ajouter ou de résoudre -->

Crée un selecteur de texte agnostique des langues pour que les tests e2e fonctionnent dans toutes les configurations
