### PR TITLE
fix: add “Content.” prefix to specific CSV fields for ReSIP import

### DIFF
--- a/src/renderer/exporters/resip/resip-exporter.ts
+++ b/src/renderer/exporters/resip/resip-exporter.ts
@@ -201,7 +201,17 @@ const formatToCsv = (sipFilesAndFolders: ResipFormat[], tags: Tag[]) => {
   ];
   const tagsFields = tags.map((_tag, index) => `Content.Tag.${index}`);
 
-  const firstRow: string[] = (fieldsOrder as string[]).concat(tagsFields);
+  // Add the “Content.” prefix where needed
+  const formatFieldName = (field: keyof ResipFormat): string => {
+    if (field === "ID" || field === "ParentID" || field === "File") {
+      return field as string;
+    }
+    return `Content.${field}`;
+  };
+
+  const firstRow: string[] = fieldsOrder
+    .map(formatFieldName)
+    .concat(tagsFields);
 
   const dataRows = sipFilesAndFolders.map((sipFileAndFolder) => {
     const baseFileAndFolder = fieldsOrder.map(


### PR DESCRIPTION
# Goal
Updated the formatToCsv function to prepend “Content.” to field names except for “ID”, “ParentID”, and “File”. This adjustment ensures compatibility with the ReSIP format when importing a CSV into Vitam:

- Added formatFieldName for conditional prefixing.
- Updated firstRow and dataRows with correct field formatting.
