### PR TITLE
Fix: update website url in variables

### DIFF
--- a/package.json
+++ b/package.json
@@ -10,7 +10,7 @@
   },
   "license": "Apache-2.0",
   "main": "dist/main/main.js",
-  "homepage": "https://archifiltre.fr/docs",
+  "homepage": "https://archifiltre.fabrique.social.gouv.fr",
   "repository": "git@github.com:SocialGouv/archifiltre-docs.git",
   "bugs": {
     "url": "https://github.com/SocialGouv/archifiltre-docs/issues"

--- a/src/renderer/constants.ts
+++ b/src/renderer/constants.ts
@@ -5,4 +5,4 @@ export const DOCUMENTATION_LINK =
   "https://github.com/SocialGouv/archifiltre-docs/wiki/Wiki-Archifiltre";
 export const SUGGEST_FEATURE_LINK =
   "https://github.com/SocialGouv/archifiltre-docs/issues";
-export const ARCHIFILTRE_SITE_URL = "https://archifiltre.fr";
+export const ARCHIFILTRE_SITE_URL = "https://archifiltre.fabrique.social.gouv.fr";


### PR DESCRIPTION
### Objectif(s)
Archifiltre website URL update following the release of the new website with a new URL
